### PR TITLE
Ft view red flags 162233045

### DIFF
--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -1,31 +1,74 @@
-
-from .red_flags import RedFlag, RedFlagSchema
+"""This file is the model that handle requests from views. Manipulates the Dict accordingly"""
+from .red_flags import RedFlagSchema, RedFlagSchemaUpdate
 from .incidence_type import IncidenceType
 
-incidence = [
-    #RedFlag(32,"7770,-452","pending",['image.png','face.jpg'],['movie.mp4','clip.mov'],"Waiting")
-]
+INCIDENCE = []
 
 class IncidenceModel():
+    """Handles the requests from exposed endpoints"""
     def __init__(self):
-        self.database = incidence
-        
-    def addIncidence(self,data):
-        
+        self.database = INCIDENCE
+    def add_incidence(self, data):
+        """Adds a new entry of flag"""
+        print(data)
         self.database.append(data)
-        return "Saved",201
-    
-    def getIncidences(self):
+        return "Saved", 201
+    def get_incidences(self):
+        """Returns all flag entries"""
         schema = RedFlagSchema(many=True)
-        
         flags = schema.dump(
-            filter(lambda i: i.type == IncidenceType.REDFLAG,incidence)
+            filter(lambda i: i.type == IncidenceType.REDFLAG, INCIDENCE)
         )
-        return { "Status":200,"Data":flags.data }
-    
-    def getSingleIncidence(self,id):
-        return id, "request received"
-    
-    def updateEntry(id):
-        return id ,"Updating"
+        return {"Status":200, "Data":schema.dump(INCIDENCE)}
+    def get_incidence_by_id(self, identifier):
+        """Gets a single entry of of flag recognized by id"""
+        flags = self.get_entry_helper(identifier)
+        return {"Status":200, "Data":flags} 
+    def update_entry(self, identifier, data):
+        """Ofcourse updates a single entry identified by id"""
+        hack = self.get_entry_helper(identifier)
+        final = hack[0]
+        #first merge to get one bit
+        schema = RedFlagSchema(many=True)
+        updated_dict = self.manual_update_helper(final, data)
+        #remove the old entry
+        old_entry = RedFlagSchemaUpdate().load(final)
+        #determine the index...
+        flags = schema.dump(INCIDENCE)
+        old_ = schema.dump(old_entry).data[0]
+        index = flags.data.index(old_)
+        #add the new & updated dict!
+        objected = RedFlagSchemaUpdate().load(updated_dict)
+        #flags.data.pop(index)
+        INCIDENCE.pop(index)
+        #self.database = flags.data
+        INCIDENCE.append(objected.data)
+        return updated_dict, "PERFECT"
+    def manual_update_helper(self, dict_one, dict_two):
+        """Manually updates the dictionary by flipping and re-assigning"""
+        fin = dict_one.copy()
+        fin.update(dict_two)
+        return fin
+    #need to dry-run this code!
+    def find_index(self, identifier):
+        """Takes in an id of an entry in dict, then returns its location in the list as Index"""
+        hack = self.get_entry_helper(identifier)
+        final = hack[0]
+        #first merge to get one bit
+        schema = RedFlagSchema(many=True)
+        #determine the index...
+        flags = schema.dump(INCIDENCE)
+        index = flags.data.index(final)
+        return index
+    def get_entry_helper(self,identifier):
+        """Dumps the dicts and gets the required entry identified by id"""
+        schema = RedFlagSchema(many=True)
+        flags = schema.dump(
+            filter(lambda i: i.id == int(identifier), INCIDENCE)
+        )
+        return flags.data
+    def remove_entry(self, identifier):
+        """Removes a single entry identifieid by id"""
+        INCIDENCE.pop(self.find_index(identifier))
+        return "OK", 204
     

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -1,19 +1,41 @@
-from flask_restful import Api,Resource
-from .models import IncidenceModel, incidence
-from .red_flags import RedFlag, RedFlagSchema
-from flask import jsonify, request
-from .incidence_type import IncidenceType
+"""
+This file receives and serves requests as api endpoints.
+"""
+from flask import request
+from flask_restful import Resource
+from .models import IncidenceModel
+from .red_flags import RedFlagSchema
 
-class iReporter(Resource, IncidenceModel):
+class iReporterFlags(Resource, IncidenceModel):
+    """
+    This class receives and serves requests as api endpoints.
+    """
     def __init__(self):
+        """Instantiate the dict as the database"""
         self.database = IncidenceModel()
-        
-    def get(self):
-       
-        return self.getIncidences()
-        
+    def get(self, identifier=None):
+        """
+        Serves the GET request, But checks if any param is given in order to determine
+        if its a single entry request or all
+        """
+        if identifier is None:
+             return self.get_incidences()
+        return self.get_incidence_by_id(identifier)
+    def put(self):
+        """Implements update to an entry"""
+        return self.database.update_entry(request.get_json())         
     def post(self):
+        """Sets new data to databae(Dict)"""
         flags = RedFlagSchema().load(request.get_json())
-        self.database.addIncidence(flags.data)
-        return 'OK',204
-        
+        self.database.add_incidence(flags.data)
+        return 'OK', 204
+    def delete(self, identifier):
+        """Basically removes a single entry provided by the id as identify"""
+        return self.database.remove_entry(identifier)     
+class User(Resource):
+    """User view handler"""
+    def __init__(self):
+        self.runs = "Waiting for name.."
+    def get(self, name):
+        """Retrieves the available entry identified by name"""
+        return name


### PR DESCRIPTION
This feature provides an endpoint that returns all the available red-flags created by the user. In the case of admin session, the user is able to view all the flags that have been created.
This PR would be used with a feature that allows it to take various params in order to filter the flags.

This would include:
`Date` of `creation` as a margin
`Location` 
`Status` eg, get all resolved flags.

This feature is still subject to improvements. 