### PR TITLE
Fixed link on login and switching admin role

### DIFF
--- a/UI/home.html
+++ b/UI/home.html
@@ -24,7 +24,7 @@
 						<span><img src="img/logo.jpg" alt="Logo image" style="width:50px; height:50px; border-radius:50%;"></span>
 						<span style="position: absolute;top: -10px;right: -10px;padding: 5px 10px; border-radius: 50%; background-color: red;color: white;">0</span>
 							<figcaption>iReporter</figcaption>
-							<figcaption><button onclick="switchAdmin();">Switch to Admin</button></figcaption>
+							<figcaption><button onclick="switchAdminRole();">Switch to Admin</button></figcaption>
 						</figure>
 			
 						

--- a/UI/js/main.js
+++ b/UI/js/main.js
@@ -94,6 +94,6 @@ function swapLogin(activate){
 function goto_home(){
    window.open("home.html","_self");
 }
-function switchAdmin(){
-   window.open("admin.html","_self");
+function switchAdminRole(){
+    window.open("admin.html","_self");
 }


### PR DESCRIPTION
This PR created a simulated login to the user dashboard, from the login page, the user can provide dummy credentials and be redirected to home.

From the user dashboard, one can also test the admin page by clicking 'switch to admin' button that would take the user to admin panel, this is for test and doesn't involve any authentication. 

This is important for enabling a user to navigate to all the pages prior to implementation of proper backend authentication. 
![Admin Dashboard after switching roles.](https://user-images.githubusercontent.com/17080971/49383109-0f775a00-f729-11e8-8a63-e3393e28568e.png) 
